### PR TITLE
fix: add start method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,6 @@ p.on('ping', function (time) {
   console.log(time + 'ms')
   p.stop() // stop sending pings
 })
+
+p.start()
 ```

--- a/test/test-ping.js
+++ b/test/test-ping.js
@@ -72,6 +72,8 @@ describe('libp2p ping', () => {
       p.stop()
       done()
     })
+
+    p.start()
   })
 
   it('ping 5 times from peerB to peerA', (done) => {
@@ -90,6 +92,8 @@ describe('libp2p ping', () => {
         done()
       }
     })
+
+    p.start()
   })
 
   it('ping itself', (done) => {
@@ -104,6 +108,8 @@ describe('libp2p ping', () => {
       p.stop()
       done()
     })
+
+    p.start()
   })
 
   it('unmount PING protocol', () => {


### PR DESCRIPTION
The lack of start implies that events might get lost since we have no way of setting up handlers before `ping` starts emitting.